### PR TITLE
Fixes incorrect zero-padding of addresses in disassembly

### DIFF
--- a/threadmap.py
+++ b/threadmap.py
@@ -160,7 +160,7 @@ class ThreadFindings(object):
                 else:
                     mode = distorm3.Decode32Bits
 
-                disassemble_code += "\n\t".join(["{0:<#010x} {1:<16} {2}".format(o, h, i) \
+                disassemble_code += "\n\t".join(["{0:#010x} {1:<16} {2}".format(o, h, i) \
                                               for o, _size, i, h in \
                                               distorm3.DecodeGenerator(entry_point, content, mode)])
 


### PR DESCRIPTION
When using distorm3 for disassembly, addresses are left aligned, which
results in incorrect addresses in the output.

For example

    0x21c00000 4d5a             POP R10
    0x21c00020 4152             PUSH R10

Instead of the correct

    0x021c0000 4d5a             POP R10
    0x021c0002 4152             PUSH R10